### PR TITLE
fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Workaround / fix to allow using [Docker Tooblox](https://www.docker.com/toolbox) from [Babun](http://babun.github.io/).
+Workaround / fix to allow using [Docker Toolbox](https://www.docker.com/toolbox) from [Babun](http://babun.github.io/).
 
 It could work for Cygwin with some little modifications, but if you are using Cygwin, you should be using Babun. It's an improved Cygwin.
 


### PR DESCRIPTION
fixed typo readme for the spelling of Docker toolbox
